### PR TITLE
IE UI bugfix plus configuration for CommonJS module support on front end

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
 					"corejs": "3.9"
 				}
 			]
-		]
+		],
+		"sourceType": "unambiguous"
 	},
 	"jest": {
 		"testEnvironment": "node",

--- a/src/client/core/Body.js
+++ b/src/client/core/Body.js
@@ -26,7 +26,7 @@ export default function Body(props) {
 					<Links routes={routes} />
 				</ul>
 			</nav>
-			<div className="main-content">{isLoading ? <Loader /> : <Switch routes={routes} {...props} />}</div>
+			<div className="main-content flex">{isLoading ? <Loader /> : <Switch routes={routes} {...props} />}</div>
 		</main>
 	);
 }

--- a/src/client/core/Body.scss
+++ b/src/client/core/Body.scss
@@ -2,6 +2,7 @@
 
 .main-content {
   overflow-y: auto;
+  flex-shrink: 0;
   flex-grow: 1;
 }
 


### PR DESCRIPTION
This addresses two minor/potential problems.

1. Importing Common JS modules in client side code written in ES 6.  This is a nice to have. When developing larger projects. It can be nice to share utilities, models, and other things between client and server. This only requires a slight change to the babel configuration to support this.
2. Minor UI change to prevent annoying IE 11 flex box headaches. It adds the `flex` class and `flex-shrink: 0` to the `main-content` div. In IE 11, containers using flebox can get weird behavior with certain types of elements exceeding the screen size or stacking. For example, adding two paragraphs that are large, can cause them to stack unless the size can be traced all the way up. The developer would still need to apply flex-shrink to their paragraphs, but it also needs to be on the parent. (We hit this issue in a project and spent way too long debugging it, flex shirnk solved the IE issue without effecting other browsers)