### PR TITLE
Added PR template for future pull requests and fixed linting issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+# Pull Request Template
+
+Please Verify the following before submitting a pull request:
+* If there is a related Github issue, the pull request name includes the issue number
+* Unit tests are added/fixed if applicable. All unit tests must pass
+* Code is formatted correctly, via prettier (npm run prettier) or terraform (terraform fmt)
+* Commit message following the Conventional Commits standard is provided below
+
+> You can delete everything above when you are ready to submit your pull request
+
+## Acceptance Criteria
+> Provide acceptance criteria as defined in the issue or what this is required to fix.
+
+## Change Description
+> Short summary of the changes introduced by this pull request.
+
+## Verification Instructions
+> How can the reviewer test/verify your pull request.
+
+## Commit Message
+> Commit message for the final reviewer to use when squash merging this pull request

--- a/src/client/core/Loader.js
+++ b/src/client/core/Loader.js
@@ -6,7 +6,6 @@ import React, { useEffect, useState } from 'react';
  */
 export default function Loader() {
 	let [isPastDelay, setIsPastDelay] = useState(false);
-	let [isMounted, setIsMounted] = useState(true);
 
 	// Use an effect to track mount and unmount
 	useEffect(() => {

--- a/src/client/entries/dashboard/index.js
+++ b/src/client/entries/dashboard/index.js
@@ -4,6 +4,6 @@ import React from 'react';
  * @function Dashboard
  * @description Dashboard component for a page full of visualizations
  */
-export default function Dashboard(props) {
+export default function Dashboard(_props) {
 	return <div className="inner">Hello From Dashboard</div>;
 }

--- a/src/client/entries/home/index.js
+++ b/src/client/entries/home/index.js
@@ -4,6 +4,6 @@ import React from 'react';
  * @function Home
  * @description Home component is the landing page for the application
  */
-export default function Home(props) {
+export default function Home(_props) {
 	return <div className="inner">Hello From Home</div>;
 }

--- a/src/client/entries/info/index.js
+++ b/src/client/entries/info/index.js
@@ -4,6 +4,6 @@ import React from 'react';
  * @function Info
  * @description Info component is for the About Us/Info page
  */
-export default function Info(props) {
+export default function Info(_props) {
 	return <div className="inner">Hello From Info</div>;
 }

--- a/src/client/entries/not-found/index.js
+++ b/src/client/entries/not-found/index.js
@@ -4,6 +4,6 @@ import React from 'react';
  * @function NotFound
  * @description NotFound component for handling incorrect routes
  */
-export default function NotFound(props) {
+export default function NotFound(_props) {
 	return <div className="inner">Sorry, We don& apos; t have what you are looking for here.</div>;
 }


### PR DESCRIPTION
This introduces a pull request template which we can use going forward to make this process a bit more clear. This is pretty much the same template we use on many projects, but stripped down to not have any project specific info in it. Teams can modify it as needed when using this in their projects.  It also fixed a couple of linter issues pointed out by Github actions.

merge commit: 

`feat: pr template for future pull requests and linter warning cleanup`