### PR TITLE
Added new regardless util

### DIFF
--- a/src/client/core/Loader.js
+++ b/src/client/core/Loader.js
@@ -10,7 +10,7 @@ export default function Loader() {
 	// Use an effect to track mount and unmount
 	useEffect(() => {
 		// Set a timeout for 200 ms, we dont need to show the loader if
-		// the app is only loading something for 20 seconds
+		// the app is only loading something for 200 ms
 		let timeout = setTimeout(() => setIsPastDelay(true), 200);
 
 		// Clear the timeout is this component is unmounted

--- a/src/utils/async.utils.js
+++ b/src/utils/async.utils.js
@@ -1,13 +1,31 @@
 /**
  * @function wrapper
  * @description Wrapper for async/await error handling
+ * @see async.utils.test.js for examples
  */
 module.exports.wrapper = (promise) => promise.then((data) => [undefined, data]).catch((err) => [err]);
 
 /**
  * @function middleware
  * @description Middleware wrapper for async/await error handling
+ * @see async.utils.test.js for examples
  */
 module.exports.middleware = (controller) => (req, res, next) => {
 	return Promise.resolve(controller(req, res, next)).catch(next);
+};
+
+/**
+ * @function regardless
+ * @description Similar to promise.all, but resolve regardless if one of the promises errors out
+ * @see async.utils.test.js for examples
+ */
+module.exports.regardless = (promises) => {
+	return Promise.all(
+		promises.map(
+			(promise) =>
+				new Promise((resolve) => {
+					promise.then(resolve).catch(resolve);
+				}),
+		),
+	);
 };

--- a/src/utils/async.utils.test.js
+++ b/src/utils/async.utils.test.js
@@ -124,5 +124,19 @@ describe('Async Utils Tests', () => {
 			expect(results[2]).toBe('tyrion');
 			expect(results[3]).toBe('daenerys');
 		});
+
+		test('should allow me to filter errors from a group of promises', async () => {
+			let errorOne = () => Promise.reject(new Error('400'));
+			let errorTwo = () => Promise.reject(new Error('404'));
+
+			let results = await regardless([errorOne(), errorTwo(), Promise.resolve(12)]);
+			let errors = results.filter((result) => result instanceof Error);
+
+			expect(errors).toHaveLength(2);
+			expect(errors[0].message).toBe('400');
+			expect(errors[1].message).toBe('404');
+			expect(results).toHaveLength(3);
+			expect(results[2]).toBe(12);
+		});
 	});
 });

--- a/src/utils/async.utils.test.js
+++ b/src/utils/async.utils.test.js
@@ -1,7 +1,7 @@
-const { wrapper, middleware } = require('./async.utils');
+const { wrapper, middleware, regardless } = require('./async.utils');
 
 describe('Async Utils Tests', () => {
-	describe('method: wrapper', () => {
+	describe('function: wrapper', () => {
 		test('should pass data back from a promise', async () => {
 			let promise = Promise.resolve('Aegon');
 			let [err, results] = await wrapper(promise);
@@ -37,7 +37,7 @@ describe('Async Utils Tests', () => {
 		});
 	});
 
-	describe('method: middleware', () => {
+	describe('function: middleware', () => {
 		test('should allow an async controller to correctly resolve data', async () => {
 			async function controller(_req, _res, _next) {
 				// Just imagine we are waiting for something
@@ -89,6 +89,40 @@ describe('Async Utils Tests', () => {
 			expect(nextMock).toHaveBeenCalledTimes(1);
 			expect(nextMock.mock.calls[0][0]).toBeDefined();
 			expect(nextMock.mock.calls[0][0].message).toBe('Fubar');
+		});
+	});
+
+	describe('function: regardless', () => {
+		test('should resolve when all promises resolve', async () => {
+			let results = await regardless([Promise.resolve('tyrion'), Promise.resolve('daenerys')]);
+
+			expect(results).toBeDefined();
+			expect(results[0]).toBe('tyrion');
+			expect(results[1]).toBe('daenerys');
+		});
+
+		test('should resolve when all promises reject', async () => {
+			let aegon = () => Promise.reject('aegon');
+			let cersei = () => Promise.reject('cersei');
+
+			let results = await regardless([aegon(), cersei()]);
+
+			expect(results).toBeDefined();
+			expect(results[0]).toBe('aegon');
+			expect(results[1]).toBe('cersei');
+		});
+
+		test('should resolve when some resolve and some reject regardless of the failures', async () => {
+			let aegon = () => Promise.reject('aegon');
+			let cersei = () => Promise.reject('cersei');
+
+			let results = await regardless([aegon(), cersei(), Promise.resolve('tyrion'), Promise.resolve('daenerys')]);
+
+			expect(results).toBeDefined();
+			expect(results[0]).toBe('aegon');
+			expect(results[1]).toBe('cersei');
+			expect(results[2]).toBe('tyrion');
+			expect(results[3]).toBe('daenerys');
 		});
 	});
 });


### PR DESCRIPTION
## Acceptance Criteria
* No issue, adding a new feature that was used quite a bit in apps using this starter

## Change Description
Added a `regardless` function which is similar to `Promise.all`.  The difference is that if `Promise.all` has a failure, the whole thing fails.  `regardless` resolves everything including the errors so you can handle things differently.  

A use case for this is processing items from a queue(I use this in a few apps based on the starter). We typically pull ten items at a time from the queue. If we use `Promise.all` and there is an error, all ten go back on the queue. `regardless` resolves all the items, and allows us to only put failures back on the queue. This prevents items being processed multiple times because an adjacent item failed. 

* Adds new function
* Adds unit tests
* Added `@see` to utils to link to example usage
* Changed `method` to `function` since these are not on a class, just single functions

## Verification Instructions
* `npm test`
* Code/comments makes sense

## Commit Message
`feat: added new promise utility`
